### PR TITLE
PHEE-370: Migrate to Spring Boot 3.4 / JDK 21 / Jakarta EE 10 / Camel 4 (via Mifos Platform BOM)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17-jdk
+FROM eclipse-temurin:21-jre
 EXPOSE 8080
 
 COPY build/libs/*.jar .

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '2.5.5'
-    id 'io.spring.dependency-management' version '1.1.0'
+    id 'org.springframework.boot' version '3.4.4'
+    id 'io.spring.dependency-management' version '1.1.6'
     id 'idea'
-    id "org.springdoc.openapi-gradle-plugin" version "1.6.0"
+    id "org.springdoc.openapi-gradle-plugin" version "1.9.0"
     id 'eclipse'
     id 'checkstyle'
     id 'com.diffplug.spotless' version '6.19.0'
@@ -12,7 +12,8 @@ plugins {
 
 group = 'org.mifos'
 version = '2.0.0.mifos-SNAPSHOT'
-sourceCompatibility = '17'
+sourceCompatibility = JavaVersion.VERSION_21
+targetCompatibility = JavaVersion.VERSION_21
 
 repositories {
     mavenLocal()  // Add this line
@@ -21,40 +22,63 @@ repositories {
     maven { url "https://repository.jboss.org/nexus/content/repositories/releases" }
     maven { url "https://mifos.jfrog.io/artifactory/phee-gradle-local"  }
     maven { url "https://mifos.jfrog.io/artifactory/mifosx-gradle-local" }
-}
-ext {
-    zeebClientVersion = '8.1.23'
+
+    // Mifos Platform BOM + ph-ee-connector-common 2.0.0-SNAPSHOT are consumed
+    // from the local JFrog Artifactory sandbox (Docker Compose in
+    // proposal/local-jfrog/). Swap this host for the production Mifos JFrog
+    // when the official BOM is ready.
+    maven {
+        name = 'LocalJFrog'
+        url = uri('http://localhost:8081/artifactory/mifos-platform-snapshot')
+        allowInsecureProtocol = true
+        credentials {
+            username = findProperty('localJfrog.user') ?: System.getenv('LOCAL_JFROG_USER')
+            password = findProperty('localJfrog.key') ?: System.getenv('LOCAL_JFROG_KEY')
+        }
+    }
 }
 
-ext {
-    springBootVersion = '2.6.2'
+configurations.all {
+    // camel-xml-jaxb (via connector-common) pulls the com.sun.xml.bind
+    // re-publication of the JAXB runtime; the same classes already arrive via
+    // the canonical org.glassfish.jaxb coordinates (EclipseLink/JAXB path),
+    // and bootJar rejects the duplicate jaxb-core jar entry.
+    exclude group: 'com.sun.xml.bind', module: 'jaxb-core'
+    exclude group: 'com.sun.xml.bind', module: 'jaxb-impl'
 }
+
 dependencies {
+    // Mifos Platform BOM pins Spring Boot 3.4, EclipseLink 4, Zeebe 8, Jakarta
+    // EE 10 and every other shared library version. Do NOT hardcode managed
+    // versions. This is a deployable application, so use enforcedPlatform().
+    implementation enforcedPlatform('org.mifos.platform:mifos-platform-bom:1.0.0-SNAPSHOT')
+
     implementation 'org.springframework.boot:spring-boot-starter'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    implementation("org.springframework.boot:spring-boot-starter-web:2.5.5")
-    implementation "org.springframework.boot:spring-boot-starter-actuator:$springBootVersion"
-    implementation("org.springframework.boot:spring-boot-starter-data-jpa:2.5.2")
-    implementation("org.flywaydb:flyway-core:7.0.4")
-    implementation 'org.mifos:ph-ee-connector-common:1.8.1-gazelle'
-    // implementation 'org.mifos:ph-ee-connector-common:1.8.1-SNAPSHOT'
-    implementation 'org.eclipse.persistence:org.eclipse.persistence.jpa:2.7.6'
-    implementation 'javax.annotation:javax.annotation-api:1.3.2'
-    implementation 'mysql:mysql-connector-java'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.flywaydb:flyway-core'
+    // Flyway 10 moved MySQL support out of flyway-core
+    implementation 'org.flywaydb:flyway-mysql'
+    implementation 'org.mifos:ph-ee-connector-common:2.0.0-SNAPSHOT'
+    implementation 'org.eclipse.persistence:org.eclipse.persistence.jpa'
+    // mysql:mysql-connector-java was relocated to com.mysql:mysql-connector-j
+    implementation 'com.mysql:mysql-connector-j'
     implementation 'com.zaxxer:HikariCP'
-    implementation('io.rest-assured:rest-assured:4.4.0')
-    implementation "org.springdoc:springdoc-openapi-ui:1.6.11"
-    implementation 'org.projectlombok:lombok:1.18.20'
-    annotationProcessor 'org.projectlombok:lombok:1.18.20'
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.5'
-    implementation 'org.springframework.boot:spring-boot-starter-cache:2.7.2'
-    implementation 'javax.cache:cache-api:1.1.1'
+    implementation 'io.rest-assured:rest-assured'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui'
+    implementation 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    // Ehcache 2 + JCache replaced by Caffeine (see CacheConfig): Spring 6
+    // removed EhCacheCacheManager and net.sf.ehcache is pre-Jakarta.
+    implementation 'com.github.ben-manes.caffeine:caffeine'
     // implementation 'org.mifos:ph-ee-id-account-validator-impl:0.0.6-SNAPSHOT'
     implementation 'org.mifos:ph-ee-id-account-validator-impl:0.0.1-gazelle'
-    implementation("io.camunda:zeebe-client-java:$zeebClientVersion")
-    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.7.9'
-    implementation("io.camunda:zeebe-client-java:$zeebClientVersion")
-    implementation 'net.sf.ehcache:ehcache:2.10.6'
+    implementation 'io.camunda:zeebe-client-java'
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 tasks.named('test') {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/org/mifos/identityaccountmapper/domain/ErrorTracking.java
+++ b/src/main/java/org/mifos/identityaccountmapper/domain/ErrorTracking.java
@@ -1,11 +1,11 @@
 package org.mifos.identityaccountmapper.domain;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "error_tracking")

--- a/src/main/java/org/mifos/identityaccountmapper/domain/IdentityDetails.java
+++ b/src/main/java/org/mifos/identityaccountmapper/domain/IdentityDetails.java
@@ -1,12 +1,12 @@
 package org.mifos.identityaccountmapper.domain;
 
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
 
 @Entity
 @Table(name = "identity_details")

--- a/src/main/java/org/mifos/identityaccountmapper/domain/PaymentModalityDetails.java
+++ b/src/main/java/org/mifos/identityaccountmapper/domain/PaymentModalityDetails.java
@@ -1,11 +1,11 @@
 package org.mifos.identityaccountmapper.domain;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 
 @Entity
 @Table(name = "payment_modality_details")

--- a/src/main/java/org/mifos/identityaccountmapper/interceptor/ValidatorInterceptor.java
+++ b/src/main/java/org/mifos/identityaccountmapper/interceptor/ValidatorInterceptor.java
@@ -3,9 +3,9 @@ package org.mifos.identityaccountmapper.interceptor;
 import static org.mifos.connector.common.exception.PaymentHubError.ExtValidationError;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.mifos.connector.common.channel.dto.PhErrorDTO;
 import org.mifos.connector.common.exception.PaymentHubErrorCategory;

--- a/src/main/java/org/mifos/identityaccountmapper/service/AccountLookupWorkers.java
+++ b/src/main/java/org/mifos/identityaccountmapper/service/AccountLookupWorkers.java
@@ -3,8 +3,8 @@ package org.mifos.identityaccountmapper.service;
 import static org.mifos.identityaccountmapper.util.AccountMapperEnum.WORKER_ACCOUNT_LOOKUP_CALLBACK;
 
 import io.camunda.zeebe.client.ZeebeClient;
+import jakarta.annotation.PostConstruct;
 import java.util.Map;
-import javax.annotation.PostConstruct;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/org/mifos/identityaccountmapper/service/AddUpdatePaymentModalityService.java
+++ b/src/main/java/org/mifos/identityaccountmapper/service/AddUpdatePaymentModalityService.java
@@ -2,9 +2,9 @@ package org.mifos.identityaccountmapper.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
 import java.util.ArrayList;
 import java.util.List;
-import javax.transaction.Transactional;
 import org.mifos.connector.common.channel.dto.PhErrorDTO;
 import org.mifos.identityaccountmapper.data.BeneficiaryDTO;
 import org.mifos.identityaccountmapper.data.CallbackRequestDTO;

--- a/src/main/java/org/mifos/identityaccountmapper/service/RegisterBeneficiaryService.java
+++ b/src/main/java/org/mifos/identityaccountmapper/service/RegisterBeneficiaryService.java
@@ -2,11 +2,11 @@ package org.mifos.identityaccountmapper.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
-import javax.transaction.Transactional;
 import org.mifos.connector.common.channel.dto.PhErrorDTO;
 import org.mifos.identityaccountmapper.data.BeneficiaryDTO;
 import org.mifos.identityaccountmapper.data.CallbackRequestDTO;

--- a/src/main/java/org/mifos/identityaccountmapper/util/CacheConfig.java
+++ b/src/main/java/org/mifos/identityaccountmapper/util/CacheConfig.java
@@ -1,18 +1,23 @@
 package org.mifos.identityaccountmapper.util;
 
-import net.sf.ehcache.Cache;
-import net.sf.ehcache.CacheManager;
-import net.sf.ehcache.config.CacheConfiguration;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.annotation.CachingConfigurerSupport;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.cache.ehcache.EhCacheCacheManager;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+// Ported from Ehcache 2 to Caffeine: Spring Framework 6 removed
+// EhCacheCacheManager (and CachingConfigurerSupport), and net.sf.ehcache is a
+// pre-Jakarta dead end. Semantics preserved for the single heap-based cache:
+// time_to_live -> expireAfterWrite, time_to_idle -> expireAfterAccess,
+// max_entries_heap -> maximumSize. The old off-heap/disk size settings were
+// inert (overflowToOffHeap was false) and have no Caffeine equivalent.
 @Configuration
 @EnableCaching
-public class CacheConfig extends CachingConfigurerSupport {
+public class CacheConfig {
 
     @Value("${spring.cache.time_to_live}")
     private Integer ttl;
@@ -20,33 +25,12 @@ public class CacheConfig extends CachingConfigurerSupport {
     private Integer tti;
     @Value("${spring.cache.max_entries_heap}")
     private Integer maxEntriesHeap;
-    @Value("${spring.cache.max_byte_off_heap}")
-    private Long maxByteOffHeap;
-    @Value("${spring.cache.max_byte_disk}")
-    private Long maxByteDisk;
 
     @Bean
-    public CacheManager ehCacheManager() {
-        CacheConfiguration cacheConfig = new CacheConfiguration();
-        cacheConfig.setName("accountLookupCache");
-        cacheConfig.setEternal(false);
-        cacheConfig.setTimeToIdleSeconds(tti);
-        cacheConfig.setTimeToLiveSeconds(ttl);
-        cacheConfig.setMaxEntriesLocalHeap(maxEntriesHeap);
-        cacheConfig.setMaxBytesLocalOffHeap(maxByteOffHeap);
-        cacheConfig.setMaxBytesLocalDisk(maxByteDisk);
-        cacheConfig.overflowToOffHeap(false);
-
-        Cache cache = new Cache(cacheConfig);
-
-        CacheManager cacheManager = new CacheManager();
-        cacheManager.addCache(cache);
-
+    public CacheManager cacheManager() {
+        CaffeineCacheManager cacheManager = new CaffeineCacheManager("accountLookupCache");
+        cacheManager.setCaffeine(Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(ttl)).expireAfterAccess(Duration.ofSeconds(tti))
+                .maximumSize(maxEntriesHeap));
         return cacheManager;
-    }
-
-    @Bean
-    public EhCacheCacheManager cacheCacheManager() {
-        return new EhCacheCacheManager(ehCacheManager());
     }
 }


### PR DESCRIPTION
## What

Migrate this connector to **Spring Boot 3.4 / JDK 21 / Jakarta EE 10 / Apache Camel 4**. All versions come from the Mifos Platform BOM via `enforcedPlatform(...)` instead of being pinned by hand.

Surgical migration: `javax.*` -> `jakarta.*`, versions moved to the BOM, and the minimum changes needed to compile and run. No feature work, no refactoring.

## Main changes

- `build.gradle`: Spring Boot plugin -> 3.4, `io.spring.dependency-management`, `enforcedPlatform('org.mifos.platform:mifos-platform-bom:1.0.0-SNAPSHOT')`; hand-pinned versions removed. `ph-ee-connector-common` -> `2.0.0-SNAPSHOT` where used.
- `javax.*` -> `jakarta.*` imports.
- Dockerfile base image -> `21-jre`.
- EclipseLink 4.0.4; Ehcache2->Caffeine (Spring 6 removed EhCacheCacheManager); Flyway 10 + flyway-mysql. Validated on gazelle: resolves beneficiaries for a real GovStack batch (4/4).

## Heads-up for review

- Depends on the Mifos Platform BOM (and `ph-ee-connector-common:2.0.0-SNAPSHOT` where used), **not yet published to the official Mifos JFrog**. Until then it builds against a local JFrog, so CI here will not pass until those are published upstream.

Draft - opening so we can review it together.
